### PR TITLE
#118 - JAR doesn't always include both slashes

### DIFF
--- a/src/main/java/com/openpojo/reflection/java/packageloader/impl/URLToFileSystemAdapter.java
+++ b/src/main/java/com/openpojo/reflection/java/packageloader/impl/URLToFileSystemAdapter.java
@@ -32,6 +32,7 @@ public class URLToFileSystemAdapter {
   private static final String FILE_PROTOCOL = "file";
   private static final String JAR_PROTOCOL = "jar";
   private static final String PROTOCOL_SEPARATOR = "://";
+  private static final String PROTOCOL_SEPARATOR_SHORT = ":";
 
   private String protocol;
   private final String authority;
@@ -68,7 +69,9 @@ public class URLToFileSystemAdapter {
   private void fixProtocolAndPath() {
     if (protocol.equals(JAR_PROTOCOL) && path.startsWith(FILE_PROTOCOL)) {
       this.protocol = FILE_PROTOCOL;
-      this.path = path.substring(FILE_PROTOCOL.length() + PROTOCOL_SEPARATOR.length());
+      int length = FILE_PROTOCOL.length() + (path.contains(PROTOCOL_SEPARATOR) ? PROTOCOL_SEPARATOR.length()
+              : PROTOCOL_SEPARATOR_SHORT.length());
+      this.path = path.substring(length);
     }
   }
 

--- a/src/test/java/com/openpojo/reflection/java/packageloader/impl/URLToFileSystemAdapterTest.java
+++ b/src/test/java/com/openpojo/reflection/java/packageloader/impl/URLToFileSystemAdapterTest.java
@@ -78,6 +78,21 @@ public class URLToFileSystemAdapterTest {
       expectedFilePath = pathSeperator + expectedFilePath;
     validateURLtoExpectedFilePath(expectedFilePath, "file://ourserver.com/A%20Server%20Path/");
   }
+  
+    @Test
+    /**
+     * Issue where scanned JAR does not create the file path correctly (gets file: instead of file://). Example of what is found:
+     *     jar:file:/Users/userid/.m2/repository/com/someproject/mydto/1.0.2-SNAPSHOT/mydto-1.0.2-SNAPSHOT.jar!/com/someproject/dto/MyDto.class
+     * 
+     * Without the change this test will throw:
+     *  com.openpojo.reflection.exception.ReflectionException: Relative path in absolute URI:
+     *  file://sers/userid/.m2/repository/com/someproject/mydto/1.0.2-SNAPSHOT/mydto-1.0.2-SNAPSHOT.jar!/com/someproject/dto/MyDto.class
+     */
+    public void issue118_JarFilepathNotFormedCorrectly() {
+      validateURLtoExpectedFilePath(rootPrefix
+        + "Users/userid/.m2/repository/com/someproject/mydto/1.0.2-SNAPSHOT/mydto-1.0.2-SNAPSHOT.jar!/com/someproject/dto/MyDto.class",
+          "jar:file:/Users/userid/.m2/repository/com/someproject/mydto/1.0.2-SNAPSHOT/mydto-1.0.2-SNAPSHOT.jar!/com/someproject/dto/MyDto.class");
+    }
 
   private void validateURLtoExpectedFilePath(String expectedFilePath, String url) {
     try {


### PR DESCRIPTION
Fixes the issue where a JAR file is found but the protocol doesn't include both slashes