### PR TITLE
Fixing order-dependent test in issue112.IssueTest

### DIFF
--- a/src/test/java/com/openpojo/issues/issue112/IssueTest.java
+++ b/src/test/java/com/openpojo/issues/issue112/IssueTest.java
@@ -19,6 +19,8 @@
 package com.openpojo.issues.issue112;
 
 import com.openpojo.issues.issue112.sample.AClassWithXMLGregorianCalendar;
+import com.openpojo.log.LoggerFactory;
+import com.openpojo.log.impl.Log4JLogger;
 import com.openpojo.reflection.PojoClass;
 import com.openpojo.reflection.PojoField;
 import com.openpojo.reflection.impl.PojoClassFactory;
@@ -48,6 +50,7 @@ public class IssueTest {
     appender = new SpyAppender();
     appender.startCaptureForLogger(GetterTester.class);
     appender.startCaptureForLogger(SetterTester.class);
+    LoggerFactory.setActiveLogger(Log4JLogger.class);
   }
 
   @After


### PR DESCRIPTION
Currently, test `shouldNotFail` in `issue112.IssueTest` fails when run after other tests in `JavaLoggerTest`. The reason is that tests in `JavaLoggerTest` set the active logger to be `JavaLogger`, but `shouldNotFail` fails when run with this logger. This pull request proposes to explicitly set the logger to be `Log4JLogger` before `shouldNotFail` runs, because the test passes when this logger is the active one.

Please let me know if you want to discuss the changes more.