### PR TITLE
Setting up logger so tests can pass when run after JavaLoggerTest

### DIFF
--- a/src/test/java/com/openpojo/validation/test/impl/LoggingTesterTest.java
+++ b/src/test/java/com/openpojo/validation/test/impl/LoggingTesterTest.java
@@ -20,6 +20,8 @@ package com.openpojo.validation.test.impl;
 
 import java.util.List;
 
+import com.openpojo.log.LoggerFactory;
+import com.openpojo.log.impl.Log4JLogger;
 import com.openpojo.reflection.PojoClass;
 import com.openpojo.reflection.PojoField;
 import com.openpojo.reflection.impl.PojoClassFactory;
@@ -55,6 +57,7 @@ public abstract class LoggingTesterTest {
         .create()
         .with(tester)
         .build();
+    LoggerFactory.setActiveLogger(Log4JLogger.class);
   }
 
   protected abstract Tester getTester();

--- a/src/test/java/com/openpojo/validation/test/impl/SerializableTesterTest.java
+++ b/src/test/java/com/openpojo/validation/test/impl/SerializableTesterTest.java
@@ -20,6 +20,8 @@ package com.openpojo.validation.test.impl;
 
 import java.util.List;
 
+import com.openpojo.log.LoggerFactory;
+import com.openpojo.log.impl.Log4JLogger;
 import com.openpojo.random.RandomFactory;
 import com.openpojo.reflection.PojoClass;
 import com.openpojo.reflection.impl.PojoClassFactory;
@@ -62,6 +64,7 @@ public class SerializableTesterTest {
 
     spyAppender = new SpyAppender();
     spyAppender.startCaptureForLogger(testerClass);
+    LoggerFactory.setActiveLogger(Log4JLogger.class);
   }
 
   @After

--- a/src/test/java/com/openpojo/validation/utils/ValidationHelperTest.java
+++ b/src/test/java/com/openpojo/validation/utils/ValidationHelperTest.java
@@ -20,6 +20,8 @@ package com.openpojo.validation.utils;
 
 import java.util.List;
 
+import com.openpojo.log.LoggerFactory;
+import com.openpojo.log.impl.Log4JLogger;
 import com.openpojo.reflection.PojoClass;
 import com.openpojo.reflection.PojoField;
 import com.openpojo.reflection.impl.PojoClassFactory;
@@ -70,6 +72,7 @@ public class ValidationHelperTest {
 
   @Test
   public void shouldReportMissingASMProperly() {
+    LoggerFactory.setActiveLogger(Log4JLogger.class);
     Validator validator = ValidatorBuilder.create()
         .with(new Tester() {
           public void run(PojoClass pojoClass) {


### PR DESCRIPTION
Similar to #135, there are other tests that fail when run after other tests in `JavaLoggerTest`. The reason for the failure is the same, and so this pull request proposes to introduce the same logic to explicitly set the logger to `Log4JLogger` before the tests that need it to be set up.

One thing to note is that these tests fail when run after tests in `JavaLoggerTest`, so another potential way to fix is to (re)set the logger in a teardown method for `JavaLoggerTest`. In this style, it would be good if `LoggerFactory` provides a method to see what the active logger is so the test can set the active logger to that one.

Please let me know if you want to discuss the changes more.