### PR TITLE
#140: NoStaticExceptFinalRule no skipping sythetic fields

### DIFF
--- a/src/main/java/com/openpojo/validation/rule/impl/NoStaticExceptFinalRule.java
+++ b/src/main/java/com/openpojo/validation/rule/impl/NoStaticExceptFinalRule.java
@@ -35,7 +35,7 @@ public class NoStaticExceptFinalRule implements Rule {
 
   public void evaluate(final PojoClass pojoClass) {
     for (PojoField fieldEntry : pojoClass.getPojoFields()) {
-      if (fieldEntry.isStatic() && !fieldEntry.isFinal()) {
+      if (!fieldEntry.isSynthetic() && fieldEntry.isStatic() && !fieldEntry.isFinal()) {
         Affirm.fail(String.format("Static fields=[%s] not marked final are not allowed", fieldEntry));
       }
     }


### PR DESCRIPTION
Unfortunately I don't know any way of creating a static synthetic field.. Therefore I didn't further test the code.
All I know is that we had to exclude synthetic field from this check because AspectJ creates synthetic static fields. 